### PR TITLE
fix: Choose the correct protocol

### DIFF
--- a/src/api/interceptors.ts
+++ b/src/api/interceptors.ts
@@ -1,4 +1,3 @@
-import { localeCurrent } from "i18n/config"
 import i18next from "i18next"
 import { QueryResponse } from "react-fetching-library"
 import { toast } from "react-toastify"
@@ -15,11 +14,11 @@ export function endpointTransform(action: Action) {
   const API_URL = process.env.REACT_APP_API_HOST
   if (API_URL == null) return ""
 
+  const protocol = process.env.NODE_ENV === "development" ? "http" : "https"
   const url = new URL(API_URL)
-  console.log(url)
 
   const actionEndpoint = action.endpoint[0] === "/" ? action.endpoint.slice(1) : action.endpoint
-  const endpoint = `${url.protocol}//${url.host}/${actionEndpoint}/`
+  const endpoint = `${protocol}://${url.host}/${actionEndpoint}/`
   const query = createQuery(action.params)
 
   return endpoint + (query && "?" + query)


### PR DESCRIPTION
During development, we use the HTTP protocol. In production, we use the HTTPS protocol.

As a result, we must strictly choose a protocol for development and production builds.

Now we can use both HTTP and HTTPS protocols, but this is incorrect. This is because https://stage.creaty.club and http://creaty.club (after merge) will not work.